### PR TITLE
#706 - CallExpression uses incorrect scope for parameters evaluation.

### DIFF
--- a/docs/articles/change-log.md
+++ b/docs/articles/change-log.md
@@ -8,6 +8,7 @@
 * [#667](https://github.com/sys27/xFunc/issues/667) - Migrate to NUnit ([#700](https://github.com/sys27/xFunc/pull/700)).
 * [#701](https://github.com/sys27/xFunc/issues/701) - Align units `ToString` implementation with parser.
 * [#704](https://github.com/sys27/xFunc/issues/704) - Lambda can't resolve a parameter ([#705](https://github.com/sys27/xFunc/pull/705)).
+* [#706](https://github.com/sys27/xFunc/issues/706) - `CallExpression` uses incorrect scope for parameters evaluation ([#707](https://github.com/sys27/xFunc/issues/707)).
 
 ## xFunc v4.3.0
 

--- a/xFunc.Maths/Expressions/CallExpression.cs
+++ b/xFunc.Maths/Expressions/CallExpression.cs
@@ -87,7 +87,7 @@ public class CallExpression : IExpression, IEquatable<CallExpression>
         var nestedScope = ExpressionParameters.CreateScoped(function.CapturedScope ?? parameters);
         var zip = function.Parameters.Zip(Parameters, (parameter, expression) => (parameter, expression));
         foreach (var (parameter, expression) in zip)
-            nestedScope[parameter] = new ParameterValue(expression.Execute(nestedScope));
+            nestedScope[parameter] = new ParameterValue(expression.Execute(parameters));
 
         var result = function.Call(nestedScope);
         if (result is Lambda lambdaResult)

--- a/xFunc.Tests/ProcessorTest.cs
+++ b/xFunc.Tests/ProcessorTest.cs
@@ -387,4 +387,26 @@ public class ProcessorTest
 
         Assert.That(result.Result, Is.EqualTo(193536720.0));
     }
+
+    [Test]
+    public void CallExpressionUsesCorrectContext1()
+    {
+        var processor = new Processor();
+        processor.Solve("f := (x) => (y) => x + y");
+        processor.Solve("add1 := f(1)");
+
+        Assert.Throws<KeyNotFoundException>(() => processor.Solve<NumberResult>("add1(x + 2)"));
+    }
+
+    [Test]
+    public void CallExpressionUsesCorrectContext2()
+    {
+        var processor = new Processor();
+        processor.Solve("f := (x) => (y) => x + y");
+        processor.Solve("add1 := f(1)");
+        processor.Solve("x := 3");
+        var result = processor.Solve<NumberResult>("add1(x + 2)");
+
+        Assert.That(result.Result, Is.EqualTo(6));
+    }
 }


### PR DESCRIPTION
Fix #706.